### PR TITLE
Use TypeElement,PackageElement,DocletEnvironment in PackageView

### DIFF
--- a/src/main/java/org/umlgraph/doclet/PackageView.java
+++ b/src/main/java/org/umlgraph/doclet/PackageView.java
@@ -1,8 +1,8 @@
 package org.umlgraph.doclet;
 
-import com.sun.javadoc.ClassDoc;
-import com.sun.javadoc.PackageDoc;
-import com.sun.javadoc.RootDoc;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.PackageElement;
+import jdk.javadoc.doclet.DocletEnvironment;
 
 /**
  * A view designed for UMLDoc, filters out everything that it's not contained in
@@ -18,19 +18,19 @@ import com.sun.javadoc.RootDoc;
 public class PackageView implements OptionProvider {
 
     private static final String[] HIDE = new String[] { "hide" };
-    private PackageDoc pd;
+    private PackageElement pd;
     private OptionProvider parent;
     private ClassMatcher matcher;
     private String outputPath;
     private Options opt;
 
-    public PackageView(String outputFolder, PackageDoc pd, RootDoc root, OptionProvider parent) {
+    public PackageView(String outputFolder, PackageElement pd, DocletEnvironment root, OptionProvider parent) {
 	this.parent = parent;
 	this.pd = pd;
 	this.matcher = new PackageMatcher(pd);
 	this.opt = parent.getGlobalOptions();
 	this.opt.setOptions(pd);
-	this.outputPath = pd.name().replace('.', '/') + "/" + pd.name() + ".dot";
+	this.outputPath = pd.getSimpleName().toString().replace('.', '/') + "/" + pd.getSimpleName().toString() + ".dot";
     }
 
     public String getDisplayName() {
@@ -46,7 +46,7 @@ public class PackageView implements OptionProvider {
 	return go;
     }
 
-    public Options getOptionsFor(ClassDoc cd) {
+    public Options getOptionsFor(TypeElement cd) {
 	Options go = parent.getGlobalOptions();
 	overrideForClass(go, cd);
 	return go;
@@ -58,13 +58,13 @@ public class PackageView implements OptionProvider {
 	return go;
     }
 
-    public void overrideForClass(Options opt, ClassDoc cd) {
+    public void overrideForClass(Options opt, TypeElement cd) {
 	opt.setOptions(cd);
 	boolean inPackage = matcher.matches(cd);
 	if (inPackage)
 	    opt.showQualified = false;
-	boolean included = inPackage || this.opt.matchesIncludeExpression(cd.qualifiedName());
-	if (!included || this.opt.matchesHideExpression(cd.qualifiedName()))
+	boolean included = inPackage || this.opt.matchesIncludeExpression(cd.getQualifiedName().toString());
+	if (!included || this.opt.matchesHideExpression(cd.getQualifiedName().toString()))
 	    opt.setOption(HIDE);
     }
 


### PR DESCRIPTION
- Use TypeElement, PackageElement and DocletEnvironment instead of ClassDoc, PackageDoc and RootDoc
- Modify the following methods, PackageView() (constructor), getOptionsFor(ClassDoc cd) to getOptionsFor(TypeElement cd), overrideForClass(Options opt, ClassDoc cd) to overrideForClass(Options opt, TypeElement cd)